### PR TITLE
Collect bundle_id and bundle_name if present and not set

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -971,6 +971,12 @@ def _tulsi_sources_aspect(target, ctx):
         else:
             bundle_id = None
 
+    # Handles missing bundle_id and bundle_name in _precompiled_apple_resource_bundle targets from rules_ios
+    if not bundle_id:
+        bundle_id = getattr(ctx.rule.attr, "bundle_id", None)
+    if not bundle_name:
+        bundle_name = getattr(ctx.rule.attr, "bundle_name", None)
+
     # Collect Swift related attributes.
     swift_defines = []
 
@@ -1062,10 +1068,6 @@ def _tulsi_sources_aspect(target, ctx):
         # else:
         #     module_name = None
 
-    if not bundle_id:
-        bundle_id = getattr(ctx.rule.attr, "bundle_id", None)
-    if not bundle_name:
-        bundle_name = getattr(ctx.rule.attr, "bundle_name", None)
     info = _struct_omitting_none(
         artifacts = artifacts,
         attr = _struct_omitting_none(**all_attributes),

--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -1062,6 +1062,10 @@ def _tulsi_sources_aspect(target, ctx):
         # else:
         #     module_name = None
 
+    if not bundle_id:
+        bundle_id = getattr(ctx.rule.attr, "bundle_id", None)
+    if not bundle_name:
+        bundle_name = getattr(ctx.rule.attr, "bundle_name", None)
     info = _struct_omitting_none(
         artifacts = artifacts,
         attr = _struct_omitting_none(**all_attributes),


### PR DESCRIPTION
Collect `bundle_id` and `bundle_name` directly if present in the rule attrs 