### PR TITLE
Collect resources from _precompiled_apple_resource_bundle

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -890,6 +890,9 @@ def _tulsi_sources_aspect(target, ctx):
     datamodels = _collect_xcdatamodeld_files(rule_attr, "datamodels")
     datamodels.extend(_collect_xcdatamodeld_files(rule_attr, "data"))
 
+    if ctx.rule.kind == "_precompiled_apple_resource_bundle":
+        datamodels.extend(_collect_xcdatamodeld_files(rule_attr, "resources"))
+
     structured_resources = _collect_resource_files(rule_attr, "data")
 
     expanded_copts = _expanded_copts(ctx, target, copts_attr)


### PR DESCRIPTION
To collect `resources` from `_precompiled_apple_resource_bundle`: https://github.com/bazel-ios/rules_ios/blob/08d05cc514f48c922209e3e6ba0f3c8fbc13fa5c/rules/precompiled_apple_resource_bundle.bzl#L235-L239

In particular this propagates `.xcdatamodel` resources to be compiled and added to the bundle