### PR TITLE
Fix build file path for external repos

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -35,6 +35,7 @@ load(
     "attrs_for_target_kind",
 )
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 
 ObjcInfo = apple_common.Objc
 
@@ -204,9 +205,11 @@ def _convert_outpath_to_symlink_path(path):
 
 def _is_file_a_directory(f):
     """Returns True is the given file is a directory."""
+
     # Starting Bazel 3.3.0, the File type as a is_directory attribute.
     if getattr(f, "is_directory", None):
         return f.is_directory
+
     # If is_directory is not in the File type, fall back to the old method:
     # As of Oct. 2016, Bazel disallows most files without extensions.
     # As a temporary hack, Tulsi treats File instances pointing at extension-less
@@ -1085,7 +1088,7 @@ def _tulsi_sources_aspect(target, ctx):
     info = _struct_omitting_none(
         artifacts = artifacts,
         attr = _struct_omitting_none(**all_attributes),
-        build_file = ctx.build_file_path,
+        build_file = paths.join(target.label.workspace_root, ctx.build_file_path),
         bundle_id = bundle_id,
         bundle_name = bundle_name,
         objc_defines = objc_defines,


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/12344 seems to be a regression from a while back that changed how `ctx.build_file_path` worked. Tulsi was piping out the wrong relative path, and both Xcode and XCHammer were misbehaving as a result.

After this tweak and https://github.com/jerrymarino/xcbuildkit/pull/33, XCHammer is able to bootstrap itself again.